### PR TITLE
Add Docker Compose setup and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,136 @@
 
 ## Intro
 For details about coresamples v2 service, see documents under [LIS-Coresamples-v2](https://vibrantamerica.atlassian.net/wiki/spaces/LIS/pages/707559427/LIS-Coresamples-v2)
+
+---
+
+## Docker Compose Local Development Setup
+
+This document describes how to run the LIS CoreSamples service and its core dependencies using Docker Compose for local development and testing.
+
+### Prerequisites
+
+*   **Docker:** Ensure Docker Engine is installed and running. (Refer to official Docker documentation for installation)
+*   **Docker Compose:** Ensure Docker Compose (usually included with Docker Desktop, or as a standalone plugin) is installed. (Refer to official Docker Compose documentation)
+*   **Git:** To clone the repository.
+*   **Make (Optional but Recommended):** The project uses a Makefile for common tasks.
+*   **Go (Optional):** If you need to modify Go code and rebuild, Go 1.19+ is required locally. The Docker build process handles Go compilation within a container.
+
+### Project Structure (Relevant for Docker Compose)
+
+*   `Dockerfile`: Used to build the `coresamples` service image.
+*   `docker-compose.yaml`: Defines the services, networks, and volumes for the local environment.
+*   `.env` (Create this file): Used to store sensitive credentials and local configuration overrides. **Do not commit this file.**
+*   `.env.example` (Recommended to create): An example file showing the variables needed in `.env`.
+*   `Makefile`: Contains helper targets like `make tidy`, `make build`.
+
+### Setup and Running
+
+1.  **Clone the Repository:**
+    ```bash
+    # git clone <repository_url>
+    # cd <repository_directory>
+    ```
+    (Assuming you are already in the cloned directory)
+
+2.  **Configuration (`.env` file):**
+
+    Create a file named `.env` in the root of the project directory (where `docker-compose.yaml` is located). This file will store your local configurations and secrets. **Do not commit the `.env` file to version control.**
+
+    **Example `.env` file content (save as `.env`):**
+    ```env
+    # MySQL Credentials
+    MYSQL_ROOT_PASSWORD_VAL=myrootpassword_changeme
+    MYSQL_USER_VAL=coresamples_user
+    MYSQL_PASSWORD_VAL=coresamples_pass_changeme
+    MYSQL_DATABASE_VAL=coresamples_db
+
+    # JWT Secret for coresamples service
+    JWT_SECRET_VAL=thisisadevelopmentsecret_pleasedontuseinprod_changeme
+
+    # Optional: Override other defaults from docker-compose.yaml if needed
+    # CORESAMPLES_LOG_LEVEL=info
+    # SENTRY_DSN_VAL=your_sentry_dsn_here
+
+    # Optional: Override default host port mappings if they conflict
+    # MYSQL_HOST_PORT=3308
+    # CONSUL_HOST_PORT=8501
+    # REDIS_HOST_PORT=6380
+    # JAEGER_AGENT_UDP_PORT=6832 # Host port for Jaeger agent
+    # JAEGER_UI_HOST_PORT=16687
+    ```
+    The `docker-compose.yaml` is configured to require some of these variables (e.g., `JWT_SECRET_VAL`, database credentials). If they are not set, Docker Compose will show an error.
+
+3.  **Build and Start Services:**
+    Open a terminal in the project root directory and run:
+    ```bash
+    docker-compose up --build
+    ```
+    *   `--build`: Forces Docker Compose to build the `coresamples` image using the `Dockerfile`. Required on the first run or after code changes.
+    *   Remove `--build` for subsequent runs if you haven't changed the `coresamples` source code or `Dockerfile`.
+    *   To run in detached mode (in the background), add the `-d` flag: `docker-compose up --build -d`.
+
+4.  **Accessing Services:**
+
+    *   **CoreSamples HTTP API:** `http://localhost:8083`
+    *   **CoreSamples gRPC API:** `localhost:8084` (requires a gRPC client)
+    *   **Consul UI:** `http://localhost:${CONSUL_HOST_PORT:-8500}` (default: `http://localhost:8500`)
+    *   **Jaeger UI:** `http://localhost:${JAEGER_UI_HOST_PORT:-16686}` (default: `http://localhost:16686`)
+    *   **MySQL:** Accessible on `localhost:${MYSQL_HOST_PORT:-3307}` (default: `localhost:3307`) via a MySQL client.
+        *   User: Value of `MYSQL_USER_VAL` from your `.env` file.
+        *   Password: Value of `MYSQL_PASSWORD_VAL` from your `.env` file.
+        *   Database: Value of `MYSQL_DATABASE_VAL` from your `.env` file.
+    *   **Redis:** Accessible on `localhost:${REDIS_HOST_PORT:-6379}` (default: `localhost:6379`) via `redis-cli`.
+
+5.  **Viewing Logs:**
+    If running in detached mode, or to view logs from all services:
+    ```bash
+    docker-compose logs -f
+    ```
+    To view logs for a specific service (e.g., `coresamples`):
+    ```bash
+    docker-compose logs -f coresamples
+    ```
+
+6.  **Stopping Services:**
+    To stop the services, press `Ctrl+C` in the terminal where `docker-compose up` is running.
+    If running in detached mode, or from another terminal:
+    ```bash
+    docker-compose down
+    ```
+    To stop and remove volumes (warning: this deletes data like your database):
+    ```bash
+    docker-compose down -v
+    ```
+
+### Development Workflow
+
+1.  **Modify Go code** in the `coresamples` project.
+2.  **Rebuild and restart** the `coresamples` service:
+    ```bash
+    docker-compose up --build -d coresamples
+    ```
+    Or, if you prefer to restart all services:
+    ```bash
+    docker-compose down && docker-compose up --build -d
+    ```
+
+### Important Notes & Limitations
+
+*   **Go Application Adaptation:** This Docker Compose setup assumes the `coresamples` Go application has been adapted (or will be adapted) to:
+    *   Recognize the `RUN_ENV=dev_docker_compose` environment variable.
+    *   Prioritize other environment variables (e.g., for DB, Redis, JWT_SECRET) over Consul lookups for critical connection settings.
+    *   Connect to Redis as a standalone instance.
+    *   Handle potential Kafka unavailability gracefully (Kafka is not included in this setup).
+*   **Kafka:** Apache Kafka is **not** included in this Docker Compose setup to keep it lightweight.
+*   **External Microservices:** Other external microservices that `coresamples` might interact with are not part of this setup.
+*   **Resource Usage:** Running multiple services can be resource-intensive.
+*   **Security:** The `.env` file is for local development convenience. Ensure it's not committed and that production configurations use secure secret management.
+
+### Troubleshooting
+
+*   **Missing Environment Variables:** If Docker Compose fails with an error like `Variable is not set and no default was provided`, ensure the required variable (e.g., `JWT_SECRET_VAL`) is defined in your `.env` file.
+*   **Service Connection Issues:** Verify hostnames and ports in `coresamples` environment variables match Docker Compose service names.
+*   **Port Conflicts:** Use the `*_HOST_PORT` variables in your `.env` file (e.g., `MYSQL_HOST_PORT=3308`) to change host-side port mappings if defaults conflict with local services.
+*   **Build Failures:** Check logs from `docker-compose build`.
+*   **Data Persistence:** Data is stored in Docker named volumes. Use `docker-compose down -v` for a clean start.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,146 @@
+version: '3.8'
+
+# LIS Backend v2 - CoreSamples Docker Compose Setup
+#
+# This file sets up the CoreSamples service along with its core dependencies
+# for local development and testing.
+#
+# It is highly recommended to use a .env file in the project root
+# to manage secrets and local configuration overrides.
+# Example .env file:
+#
+# MYSQL_ROOT_PASSWORD_VAL=myrootpassword_changeme
+# MYSQL_USER_VAL=coresamples_user
+# MYSQL_PASSWORD_VAL=coresamples_pass_changeme
+# MYSQL_DATABASE_VAL=coresamples_db
+# JWT_SECRET_VAL=thisisadevelopmentsecret_pleasedontuseinprod_changeme
+#
+# # Optional overrides for host ports or log levels:
+# # CORESAMPLES_LOG_LEVEL=info
+# # MYSQL_HOST_PORT=3308
+# # CONSUL_HOST_PORT=8501
+# # REDIS_HOST_PORT=6380
+# # JAEGER_AGENT_UDP_PORT=6832 # Remember to update JAEGER_AGENT_PORT for coresamples if you change this
+# # JAEGER_UI_HOST_PORT=16687
+
+services:
+  coresamples:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: coresamples_service
+    ports:
+      - "8083:8083" # HTTP
+      - "8084:8084" # gRPC
+    environment:
+      - RUN_ENV=dev_docker_compose
+      - LOG_LEVEL=${CORESAMPLES_LOG_LEVEL:-debug}
+      - JWT_SECRET=${JWT_SECRET_VAL:?Error: JWT_SECRET_VAL must be set in .env file}
+      - SENTRY_DSN=${SENTRY_DSN_VAL:-} # Defaults to empty, disabling Sentry
+
+      # Service Discovery & Basic Config (still allow connecting to Consul)
+      - CONSUL_HTTP_ADDR=consul:8500
+      - CONSUL_TOKEN= # No token for local dev Consul by default
+
+      # Database Configuration (intended to override Consul lookups in Go app)
+      - MYSQL_HOST=mysql
+      - MYSQL_PORT=3306
+      - MYSQL_USER=${MYSQL_USER_VAL:?Error: MYSQL_USER_VAL must be set in .env file}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD_VAL:?Error: MYSQL_PASSWORD_VAL must be set in .env file}
+      - MYSQL_DATABASE=${MYSQL_DATABASE_VAL:?Error: MYSQL_DATABASE_VAL must be set in .env file}
+      # - MYSQL_DISABLE_TLS=true # Add if Go code supports disabling DB TLS via ENV for dev
+
+      # Redis Configuration (intended to override Consul for standalone Redis in Go app)
+      - REDIS_ADDR=redis:6379
+      # - REDIS_PASSWORD= # No password for local dev Redis by default
+
+      # Jaeger Configuration
+      - JAEGER_AGENT_HOST=jaeger
+      - JAEGER_AGENT_PORT=${JAEGER_AGENT_INTERNAL_PORT:-6831} # Internal port Jaeger agent listens on
+      - JAEGER_SERVICE_NAME=coresamples_v2
+
+      # Kafka - Not included in this compose. App should be resilient.
+      # - KAFKA_BROKERS=kafka:9092
+
+    depends_on:
+      mysql:
+        condition: service_healthy
+      consul:
+        condition: service_started
+      redis:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
+    networks:
+      - lis_network
+
+  mysql:
+    image: mysql:8.0
+    container_name: mysql_db
+    ports:
+      - "${MYSQL_HOST_PORT:-3307}:3306" # Mapped to 3307 on host by default
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD_VAL:?Error: MYSQL_ROOT_PASSWORD_VAL must be set in .env file}
+      - MYSQL_DATABASE=${MYSQL_DATABASE_VAL:?Error: MYSQL_DATABASE_VAL must be set in .env file}
+      - MYSQL_USER=${MYSQL_USER_VAL:?Error: MYSQL_USER_VAL must be set in .env file}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD_VAL:?Error: MYSQL_PASSWORD_VAL must be set in .env file}
+    volumes:
+      - mysql_data:/var/lib/mysql
+      # Optional: ./mysql-init:/docker-entrypoint-initdb.d # For custom init scripts
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "-u$$MYSQL_USER", "-p$$MYSQL_PASSWORD"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - lis_network
+
+  consul:
+    image: consul:1.15.4
+    container_name: consul_server
+    ports:
+      - "${CONSUL_HOST_PORT:-8500}:8500" # Consul UI & API
+    volumes:
+      - consul_data:/consul/data
+      # Optional: ./consul-config:/consul/config # For pre-loading K/V data
+    command: agent -dev -ui -client=0.0.0.0 -enable-script-checks=true
+    networks:
+      - lis_network
+
+  redis:
+    image: redis:7.0-alpine
+    container_name: redis_cache
+    ports:
+      - "${REDIS_HOST_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - lis_network
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.48.0
+    container_name: jaeger_tracing
+    ports:
+      - "${JAEGER_AGENT_UDP_PORT:-6831}:6831/udp" # Agent UDP listening port
+      - "${JAEGER_UI_HOST_PORT:-16686}:16686"   # Jaeger UI
+    environment:
+      - COLLECTOR_ZIPKIN_HOST_PORT=:9411 # Optional
+      - LOG_LEVEL=${JAEGER_LOG_LEVEL:-debug}
+      # Ensure JAEGER_AGENT_HOST in coresamples points to this service,
+      # and JAEGER_AGENT_PORT matches the internal UDP port (default 6831)
+    networks:
+      - lis_network
+
+volumes:
+  mysql_data:
+  consul_data:
+  redis_data:
+
+networks:
+  lis_network:
+    driver: bridge


### PR DESCRIPTION
This commit introduces:
1. A new `docker-compose.yaml` file to enable local development of the CoreSamples service with its core dependencies (MySQL, Consul, Redis, Jaeger).
2. Updated `README.md` with detailed instructions on how to set up and use the Docker Compose environment, including configuration via an .env file, service access, and development workflow.

This setup aims to simplify local development by providing a reproducible environment and relies on environment variables for configuring the CoreSamples application, reducing dependency on a pre-populated Consul for startup.