### PR TITLE
Add .env.example for Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# This is an example .env file for the Docker Compose setup.
+# Copy this file to .env and fill in your actual values.
+# Do NOT commit your actual .env file to version control.
+
+# --- MySQL Credentials ---
+# Root password for the MySQL container (used by Docker to initialize the DB)
+MYSQL_ROOT_PASSWORD_VAL=myrootpassword_changeme
+
+# Dedicated user and password for the CoreSamples application to connect to MySQL
+MYSQL_USER_VAL=coresamples_user
+MYSQL_PASSWORD_VAL=coresamples_pass_changeme
+
+# Database name for the CoreSamples application
+MYSQL_DATABASE_VAL=coresamples_db
+
+# --- JWT Secret for CoreSamples service ---
+# Replace with a strong, unique secret for JWT token generation
+JWT_SECRET_VAL=thisisadevelopmentsecret_pleasedontuseinprod_changeme
+
+# --- Optional: CoreSamples Service Configuration ---
+# Log level for the CoreSamples service (e.g., debug, info, warn, error)
+# CORESAMPLES_LOG_LEVEL=debug
+
+# Sentry DSN for error reporting (leave empty to disable)
+# SENTRY_DSN_VAL=your_sentry_dsn_here
+
+# --- Optional: Host Port Mappings ---
+# If default host ports conflict with your local setup, you can change them here.
+# The format is: DESIRED_HOST_PORT
+# MYSQL_HOST_PORT=3307
+# CONSUL_HOST_PORT=8500
+# REDIS_HOST_PORT=6379
+# JAEGER_AGENT_UDP_PORT=6831 # Host port for Jaeger agent UDP traffic
+# JAEGER_UI_HOST_PORT=16686  # Host port for Jaeger UI
+
+# --- Optional: Jaeger Configuration ---
+# Log level for Jaeger (e.g., debug, info, error)
+# JAEGER_LOG_LEVEL=debug
+
+# --- Note on CoreSamples Application Code ---
+# For this Docker Compose setup to work as intended (especially regarding DB and Redis connections),
+# the CoreSamples Go application code needs to be adapted to:
+# 1. Recognize the RUN_ENV=dev_docker_compose environment variable.
+# 2. Prioritize environment variables (like MYSQL_HOST, REDIS_ADDR, JWT_SECRET_VAL) 
+#    over fetching these configurations from Consul.
+# 3. Connect to Redis as a standalone instance when in dev_docker_compose mode.
+# 4. Handle Kafka unavailability gracefully (as Kafka is not included in this basic setup).


### PR DESCRIPTION
This commit adds a .env.example file to provide a template for you setting up your local environment for the Docker Compose configuration. It includes placeholders for necessary environment variables such as database credentials, JWT secret, and optional port mappings.

This supports the Docker Compose setup recently added, making it easier for you to configure your local instance of the CoreSamples service.