### PR TITLE
Refactor: Improve Consul address handling for Docker Compose

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,23 +65,20 @@ func main() {
 			localConsulClient = common.GetConsulApiClient("http", "192.168.60.9", 8500, common.Env.LocalConsulToken, "")
 		}
 	} else if common.Env.RunEnv == common.DevDockerComposeEnv {
-		consulAddr := os.Getenv("CONSUL_HTTP_ADDR")
-		if consulAddr == "" {
-			common.Fatal(fmt.Errorf("CONSUL_HTTP_ADDR environment variable not set for dev_docker_compose mode"))
+		common.InfoFields("DevDockerComposeEnv: Attempting to use Consul address from common.Env.ConsulConfigAddr", zap.String("consul_config_addr", common.Env.ConsulConfigAddr))
+		if common.Env.ConsulConfigAddr == "" {
+			common.Fatal(fmt.Errorf("common.Env.ConsulConfigAddr is empty for DevDockerComposeEnv. Ensure CONSUL_HTTP_ADDR is set or defaults are working."))
 		}
-		parts := strings.Split(consulAddr, ":")
+		parts := strings.Split(common.Env.ConsulConfigAddr, ":")
 		if len(parts) != 2 {
-			common.Fatal(fmt.Errorf("invalid CONSUL_HTTP_ADDR format: %s. Expected host:port", consulAddr))
+			common.Fatal(fmt.Errorf("common.Env.ConsulConfigAddr is malformed for DevDockerComposeEnv: %s. Expected host:port", common.Env.ConsulConfigAddr))
 		}
 		host := parts[0]
 		portStr := parts[1]
 		port, err := strconv.ParseInt(portStr, 10, 64)
 		if err != nil {
-			common.Fatal(fmt.Errorf("invalid port in CONSUL_HTTP_ADDR: %s. Error: %w", portStr, err))
+			common.Fatal(fmt.Errorf("invalid port in common.Env.ConsulConfigAddr for DevDockerComposeEnv: %s. Error: %w", portStr, err))
 		}
-		common.InfoFields("Using Consul address from CONSUL_HTTP_ADDR for dev_docker_compose mode.",
-			zap.String("host", host),
-			zap.Int64("port", port))
 		consulClient = common.GetConsulApiClient("http", host, port, common.Env.ConsulToken, "")
 	} else {
 		consulClient = common.GetConsulApiClient("http", common.Env.ConsulConfigAddr, 8500, common.Env.ConsulToken, "")


### PR DESCRIPTION
This commit refines the Consul address initialization for the `DevDockerComposeEnv` mode.

Key changes in `main.go`:
- The Consul client initialization for `DevDockerComposeEnv` now strictly relies on `common.Env.ConsulConfigAddr`. The `common.InitEnv()` function is already responsible for setting this value based on the `CONSUL_HTTP_ADDR` environment variable, or defaulting to `localhost:8500` if the environment variable is not set.
- Added specific logging before attempting to parse/use `common.Env.ConsulConfigAddr` to clearly show what address the application is configured to use.
- Removed redundant reads of `os.Getenv("CONSUL_HTTP_ADDR")` within the `DevDockerComposeEnv` block in `main.go`, as this is handled by `common.InitEnv()`.

This approach centralizes the Consul address determination logic within `common.InitEnv()` and ensures `main.go` uses this configured value, while providing better diagnostic logs. If `CONSUL_HTTP_ADDR` is not correctly set in the environment, `common.InitEnv` will cause `Env.ConsulConfigAddr` to be "localhost:8500", which will then be logged and used, leading to the connection error if Consul is not actually at localhost.